### PR TITLE
fix: TEXT_TO_SQL_RULES add RULE "DON'T BE keywords the alias of table…

### DIFF
--- a/dat-agents/dat-agent-agentic/src/main/resources/prompts/agentic/text_to_sql_rules.txt
+++ b/dat-agents/dat-agent-agentic/src/main/resources/prompts/agentic/text_to_sql_rules.txt
@@ -3,6 +3,7 @@
 - ONLY USE "*" if the user query asks for all the columns of a table.
 - ONLY CHOOSE columns belong to the tables mentioned in the database schema.
 - DON'T INCLUDE comments and line breaks in the generated SQL query.
+- DON'T BE keywords the alias of tables and columns in the generated SQL query.
 - YOU MUST USE "JOIN" if you choose columns from multiple tables!
 - ALWAYS QUALIFY column names with their table name or table alias to avoid ambiguity (e.g., orders.OrderId, o.OrderId)
 - YOU MUST USE "lower(<table_name>.<column_name>) like lower(<value>)" function or "lower(<table_name>.<column_name>) = lower(<value>)" function for case-insensitive comparison!

--- a/dat-core/src/main/resources/prompts/default/text_to_sql_rules.txt
+++ b/dat-core/src/main/resources/prompts/default/text_to_sql_rules.txt
@@ -3,6 +3,7 @@
 - ONLY USE "*" if the user query asks for all the columns of a table.
 - ONLY CHOOSE columns belong to the tables mentioned in the database schema.
 - DON'T INCLUDE comments and line breaks in the generated SQL query.
+- DON'T BE keywords the alias of tables and columns in the generated SQL query.
 - YOU MUST USE "JOIN" if you choose columns from multiple tables!
 - ALWAYS QUALIFY column names with their table name or table alias to avoid ambiguity (e.g., orders.OrderId, o.OrderId)
 - YOU MUST USE "lower(<table_name>.<column_name>) like lower(<value>)" function or "lower(<table_name>.<column_name>) = lower(<value>)" function for case-insensitive comparison!


### PR DESCRIPTION
…s and columns in the generated SQL query"