### PR TITLE
improvement: modify the default value of Semantic model indexing meth…

### DIFF
--- a/dat-core/src/main/java/ai/dat/core/contentstore/DefaultContentStore.java
+++ b/dat-core/src/main/java/ai/dat/core/contentstore/DefaultContentStore.java
@@ -154,7 +154,7 @@ public class DefaultContentStore implements ContentStore {
 
         // -------------------------------------------- Semantic Model ------------------------------------------
         this.mdlIndexingMethod = Optional.ofNullable(mdlIndexingMethod)
-                .orElse(SemanticModelIndexingMethod.FE);
+                .orElse(SemanticModelIndexingMethod.CE);
         this.mdlHyQEAssistant = AiServices.builder(MdlHyQEAssistant.class)
                 .chatModel(Objects.requireNonNullElse(mdlHyQEChatModel, defaultChatModel))
                 .build();
@@ -172,7 +172,7 @@ public class DefaultContentStore implements ContentStore {
 
         // -------------------------------------------- Business Knowledge -------------------------------------
         this.docIndexingMethod = Optional.ofNullable(docIndexingMethod)
-                .orElse(BusinessKnowledgeIndexingMethod.FE);
+                .orElse(BusinessKnowledgeIndexingMethod.PCCE);
 
         this.docGCEMaxChunkSize = Optional.ofNullable(docGCEMaxChunkSize).orElse(512);
         Preconditions.checkArgument(this.docGCEMaxChunkSize > 0,
@@ -198,8 +198,8 @@ public class DefaultContentStore implements ContentStore {
         this.docPCCEChildChunkRegex = docPCCEChildChunkRegex;
 
         this.docMaxResults = Optional.ofNullable(docMaxResults).orElse(this.maxResults);
-        Preconditions.checkArgument(this.docMaxResults <= 100 && this.docMaxResults >= 1,
-                "docMaxResults must be between 1 and 100");
+        Preconditions.checkArgument(this.docMaxResults <= 200 && this.docMaxResults >= 1,
+                "docMaxResults must be between 1 and 200");
         this.docMinScore = Optional.ofNullable(docMinScore).orElse(this.minScore);
         Preconditions.checkArgument(this.docMinScore >= 0.0 && this.docMinScore <= 1.0,
                 "docMinScore must be between 0.0 and 1.0");

--- a/dat-core/src/main/java/ai/dat/core/factories/DefaultContentStoreFactory.java
+++ b/dat-core/src/main/java/ai/dat/core/factories/DefaultContentStoreFactory.java
@@ -72,7 +72,7 @@ public class DefaultContentStoreFactory implements ContentStoreFactory {
     public static final ConfigOption<SemanticModelIndexingMethod> SEMANTIC_MODEL_INDEXING_METHOD =
             ConfigOptions.key("semantic-model.indexing-method")
                     .enumType(SemanticModelIndexingMethod.class)
-                    .defaultValue(SemanticModelIndexingMethod.FE)
+                    .defaultValue(SemanticModelIndexingMethod.CE)
                     .withDescription("Semantic model indexing method.\n" +
                             Arrays.stream(SemanticModelIndexingMethod.values())
                                     .map(e -> e.name() + ": " + e.getDescription())
@@ -116,7 +116,7 @@ public class DefaultContentStoreFactory implements ContentStoreFactory {
     public static final ConfigOption<BusinessKnowledgeIndexingMethod> BUSINESS_KNOWLEDGE_INDEXING_METHOD =
             ConfigOptions.key("business-knowledge.indexing-method")
                     .enumType(BusinessKnowledgeIndexingMethod.class)
-                    .defaultValue(BusinessKnowledgeIndexingMethod.FE)
+                    .defaultValue(BusinessKnowledgeIndexingMethod.PCCE)
                     .withDescription("Business knowledge indexing method.\n" +
                             Arrays.stream(BusinessKnowledgeIndexingMethod.values())
                                     .map(e -> e.name() + ": " + e.getDescription())
@@ -180,7 +180,7 @@ public class DefaultContentStoreFactory implements ContentStoreFactory {
             ConfigOptions.key("business-knowledge.retrieval.max-results")
                     .intType()
                     .noDefaultValue()
-                    .withDescription("Business knowledge retrieve TopK maximum value, must be between 1 and 100. " +
+                    .withDescription("Business knowledge retrieve TopK maximum value, must be between 1 and 200. " +
                             "If not set, use the max-results.");
 
     public static final ConfigOption<Double> BUSINESS_KNOWLEDGE_RETRIEVAL_MIN_SCORE =
@@ -517,8 +517,8 @@ public class DefaultContentStoreFactory implements ContentStoreFactory {
                 "'" + BUSINESS_KNOWLEDGE_INDEXING_PCCE_CHILD_MAX_CHUNK_SIZE.key() + "' value must be less than '"
                         + BUSINESS_KNOWLEDGE_INDEXING_PCCE_PARENT_MAX_CHUNK_SIZE.key() + "' value");
         config.getOptional(BUSINESS_KNOWLEDGE_RETRIEVAL_MAX_RESULTS)
-                .ifPresent(n -> Preconditions.checkArgument(n >= 1 && n <= 100,
-                        "'" + BUSINESS_KNOWLEDGE_RETRIEVAL_MAX_RESULTS.key() + "' value must be between 1 and 100"));
+                .ifPresent(n -> Preconditions.checkArgument(n >= 1 && n <= 200,
+                        "'" + BUSINESS_KNOWLEDGE_RETRIEVAL_MAX_RESULTS.key() + "' value must be between 1 and 200"));
         config.getOptional(BUSINESS_KNOWLEDGE_RETRIEVAL_MIN_SCORE)
                 .ifPresent(n -> Preconditions.checkArgument(n >= 0.0 && n <= 1.0,
                         "'" + BUSINESS_KNOWLEDGE_RETRIEVAL_MIN_SCORE.key() + "' value must be between 0.0 and 1.0"));


### PR DESCRIPTION
…od to 'CE', and modify the default value of business knowledge indexing method to 'PCCE'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Refined default indexing strategies for semantic models and business knowledge to optimize retrieval performance.
  * Increased the maximum number of business knowledge documents retrievable per query from 100 to 200, enabling broader search coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->