### PR TITLE
fix: MsMarcoMiniLmL6V2ScoringModelFactory factory identifier to 'ms-marco-MiniLM-L6-v2'

### DIFF
--- a/dat-rerankers/dat-reranker-ms-marco-minilm-l6-v2/src/main/java/ai/dat/reranker/onnx/MsMarcoMiniLmL6V2ScoringModelFactory.java
+++ b/dat-rerankers/dat-reranker-ms-marco-minilm-l6-v2/src/main/java/ai/dat/reranker/onnx/MsMarcoMiniLmL6V2ScoringModelFactory.java
@@ -14,7 +14,7 @@ import java.util.Set;
  */
 public class MsMarcoMiniLmL6V2ScoringModelFactory implements ScoringModelFactory {
 
-    public static final String IDENTIFIER = "ms-marco-MiniLM-L6-v2-q";
+    public static final String IDENTIFIER = "ms-marco-MiniLM-L6-v2";
 
     @Override
     public String factoryIdentifier() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the MS Marco MiniLM L6 v2 reranker model identifier to ensure proper model recognition and system integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->