### PR TITLE
fix: semantic sql to dialect sql identifier quote change to an empty string

### DIFF
--- a/dat-adapters/dat-adapter-duckdb/src/main/java/ai/dat/adapter/duckdb/DuckDBSemanticAdapter.java
+++ b/dat-adapters/dat-adapter-duckdb/src/main/java/ai/dat/adapter/duckdb/DuckDBSemanticAdapter.java
@@ -11,9 +11,13 @@ import org.apache.calcite.sql.dialect.DuckDBSqlDialect;
  * @Date 2025/9/16
  */
 public class DuckDBSemanticAdapter implements SemanticAdapter {
+
+    public static final SqlDialect DEFAULT = new DuckDBSqlDialect(
+            DuckDBSqlDialect.DEFAULT_CONTEXT.withIdentifierQuoteString(""));
+
     @Override
     public SqlDialect getSqlDialect() {
-        return DuckDBSqlDialect.DEFAULT;
+        return DEFAULT;
     }
 
     @Override

--- a/dat-adapters/dat-adapter-mysql/src/main/java/ai/dat/adapter/mysql/MySqlSemanticAdapter.java
+++ b/dat-adapters/dat-adapter-mysql/src/main/java/ai/dat/adapter/mysql/MySqlSemanticAdapter.java
@@ -13,9 +13,12 @@ import org.apache.calcite.sql.SqlDialect;
  */
 public class MySqlSemanticAdapter implements SemanticAdapter {
 
+    public static final SqlDialect DEFAULT = new DatMysqlSqlDialect(
+            DatMysqlSqlDialect.DEFAULT_CONTEXT.withIdentifierQuoteString(""));
+
     @Override
     public SqlDialect getSqlDialect() {
-        return DatMysqlSqlDialect.DEFAULT;
+        return DEFAULT;
     }
 
     @Override

--- a/dat-adapters/dat-adapter-oracle/src/main/java/ai/dat/adapter/oracle/OracleSemanticAdapter.java
+++ b/dat-adapters/dat-adapter-oracle/src/main/java/ai/dat/adapter/oracle/OracleSemanticAdapter.java
@@ -11,9 +11,12 @@ import org.apache.calcite.sql.dialect.OracleSqlDialect;
  */
 public class OracleSemanticAdapter implements SemanticAdapter {
 
+    public static final SqlDialect DEFAULT = new OracleSqlDialect(
+            OracleSqlDialect.DEFAULT_CONTEXT.withIdentifierQuoteString(""));
+
     @Override
     public SqlDialect getSqlDialect() {
-        return OracleSqlDialect.DEFAULT;
+        return DEFAULT;
     }
 
     @Override
@@ -46,8 +49,7 @@ public class OracleSemanticAdapter implements SemanticAdapter {
             case "BINARY_DOUBLE" ->
                 // Oracle的BINARY_DOUBLE映射为DOUBLE
                     AnsiSqlType.DOUBLE;
-            case "FLOAT" ->
-                    AnsiSqlType.FLOAT;
+            case "FLOAT" -> AnsiSqlType.FLOAT;
             case "VARCHAR2", "NVARCHAR2" ->
                 // Oracle的VARCHAR2映射为VARCHAR
                     AnsiSqlType.VARCHAR;

--- a/dat-adapters/dat-adapter-postgresql/src/main/java/ai/dat/adapter/postgresql/PostgreSqlSemanticAdapter.java
+++ b/dat-adapters/dat-adapter-postgresql/src/main/java/ai/dat/adapter/postgresql/PostgreSqlSemanticAdapter.java
@@ -14,9 +14,12 @@ import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
  */
 class PostgreSqlSemanticAdapter implements SemanticAdapter {
 
+    public static final SqlDialect DEFAULT = new PostgresqlSqlDialect(
+            PostgresqlSqlDialect.DEFAULT_CONTEXT.withIdentifierQuoteString(""));
+
     @Override
     public SqlDialect getSqlDialect() {
-        return PostgresqlSqlDialect.DEFAULT;
+        return DEFAULT;
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized SQL dialect handling across database adapters (DuckDB, MySQL, Oracle, and PostgreSQL) to ensure consistent configuration and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->