### PR TITLE
feat: add support for streamable HTTP MCP server

### DIFF
--- a/dat-servers/dat-server-mcp/pom.xml
+++ b/dat-servers/dat-server-mcp/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.0</version>
             <exclusions>
                 <!-- 排除spring-jcl，避免与commons-logging冲突 -->
                 <exclusion>

--- a/dat-servers/dat-server-mcp/src/main/resources/application-mcp.yml
+++ b/dat-servers/dat-server-mcp/src/main/resources/application-mcp.yml
@@ -6,7 +6,7 @@ spring:
       server:
         # Server identification
         name: dat-mcp-server
-        version: 0.0.1
+        version: 1.0.0
         # Server type (SYNC/ASYNC)
         type: SYNC
         # Transport configuration
@@ -15,3 +15,5 @@ spring:
         tool-change-notification: true
         resource-change-notification: true
         prompt-change-notification: true
+        # MCP server protocol (STREAMABLE/STATELESS)
+        #protocol: STREAMABLE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transport type selection option now available for server startup via new `-t/--transport` flag, supporting SSE (default), STREAMABLE, and STATELESS protocols.

* **Chores**
  * Server version bumped to 1.0.0.
  * Build framework dependencies updated to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->