### PR TITLE
fix: configuration description of the YAML template renders the array type

### DIFF
--- a/dat-core/src/main/java/ai/dat/core/configuration/ConfigOption.java
+++ b/dat-core/src/main/java/ai/dat/core/configuration/ConfigOption.java
@@ -48,13 +48,10 @@ public class ConfigOption<T> {
     @Getter
     private final Class<?> clazz;
 
+    @Getter
     private final boolean isList;
 
     // ------------------------------------------------------------------------
-
-    boolean isList() {
-        return isList;
-    }
 
     /**
      * Creates a new config option with fallback keys.

--- a/dat-core/src/main/java/ai/dat/core/utils/YamlTemplateUtil.java
+++ b/dat-core/src/main/java/ai/dat/core/utils/YamlTemplateUtil.java
@@ -132,8 +132,9 @@ public class YamlTemplateUtil {
             }
             defaultValueDescription = ", Default: " + defaultValue;
         }
+        String classSimpleName = configOption.getClazz().getSimpleName();
         String prefix = "("
-                + configOption.getClazz().getSimpleName() + ", "
+                + (configOption.isList() ? "List<" + classSimpleName + ">" : classSimpleName) + ", "
                 + (required ? "[Required]" : "[Optional]")
                 + defaultValueDescription
                 + ")";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored configuration class to use code generation best practices.

* **Documentation**
  * Enhanced clarity of collection-type descriptions in configuration metadata by explicitly denoting list wrapper types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->