### PR TITLE
workflow: set 'central.publishing.timeout'(default: 600) to 1800

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
       - name: Deploy to Maven Central
-        run: mvn -B clean deploy -P central
+        run: mvn -B clean deploy -P central -Dcentral.publishing.timeout=1800
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment configuration to improve publishing reliability.

---

*Note: This release contains internal infrastructure improvements with no direct impact to end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->