### PR TITLE
fix: weaviate embedding store class name prefix must start from an uppercase letter

### DIFF
--- a/dat-storers/dat-storer-weaviate/src/main/java/ai/dat/storer/weaviate/WeaviateEmbeddingStoreFactory.java
+++ b/dat-storers/dat-storer-weaviate/src/main/java/ai/dat/storer/weaviate/WeaviateEmbeddingStoreFactory.java
@@ -23,7 +23,7 @@ public class WeaviateEmbeddingStoreFactory implements EmbeddingStoreFactory {
 
     public static final String IDENTIFIER = "weaviate";
 
-    public static final String DEFAULT_CLASS_NAME_PREFIX = "dat_embeddings";
+    public static final String DEFAULT_CLASS_NAME_PREFIX = "DatEmbeddings";
 
     public static final ConfigOption<String> SCHEME =
             ConfigOptions.key("scheme")
@@ -53,7 +53,8 @@ public class WeaviateEmbeddingStoreFactory implements EmbeddingStoreFactory {
             ConfigOptions.key("class-name-prefix")
                     .stringType()
                     .defaultValue(DEFAULT_CLASS_NAME_PREFIX)
-                    .withDescription("Weaviate class name prefix");
+                    .withDescription("The object class prefix you want to store, e.g. \"MyGreatClass\". " +
+                            "Must start from an uppercase letter.");
 
     @Override
     public String factoryIdentifier() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default Weaviate class naming convention to uppercase format. Documentation clarified to specify that class name prefixes should start with an uppercase letter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->