### PR TITLE
improvement: reconsider required vs. optional classification

### DIFF
--- a/dat-storers/dat-storer-milvus/src/main/java/ai/dat/storer/milvus/MilvusEmbeddingStoreFactory.java
+++ b/dat-storers/dat-storer-milvus/src/main/java/ai/dat/storer/milvus/MilvusEmbeddingStoreFactory.java
@@ -86,12 +86,12 @@ public class MilvusEmbeddingStoreFactory implements EmbeddingStoreFactory {
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
-        return new LinkedHashSet<>(List.of(USERNAME, PASSWORD, DIMENSION));
+        return new LinkedHashSet<>(List.of(HOST, PORT, USERNAME, PASSWORD, DIMENSION));
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return new LinkedHashSet<>(List.of(HOST, PORT, DATABASE_NAME, COLLECTION_NAME_PREFIX,
+        return new LinkedHashSet<>(List.of(DATABASE_NAME, COLLECTION_NAME_PREFIX,
                 CONSISTENCY_LEVEL, AUTO_FLUSH_ON_INSERT));
     }
 

--- a/dat-storers/dat-storer-pgvector/src/main/java/ai/dat/storer/pgvector/PGVectorEmbeddingStoreFactory.java
+++ b/dat-storers/dat-storer-pgvector/src/main/java/ai/dat/storer/pgvector/PGVectorEmbeddingStoreFactory.java
@@ -96,12 +96,12 @@ public class PGVectorEmbeddingStoreFactory implements EmbeddingStoreFactory {
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
-        return new LinkedHashSet<>(List.of(USER, PASSWORD, DATABASE, DIMENSION));
+        return new LinkedHashSet<>(List.of(HOST, PORT, USER, PASSWORD, DATABASE, DIMENSION));
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return new LinkedHashSet<>(List.of(HOST, PORT, TABLE_PREFIX, USE_INDEX, INDEX_LIST_SIZE));
+        return new LinkedHashSet<>(List.of(TABLE_PREFIX, USE_INDEX, INDEX_LIST_SIZE));
     }
 
     @Override

--- a/dat-storers/dat-storer-qdrant/src/main/java/ai/dat/storer/qdrant/QdrantEmbeddingStoreFactory.java
+++ b/dat-storers/dat-storer-qdrant/src/main/java/ai/dat/storer/qdrant/QdrantEmbeddingStoreFactory.java
@@ -75,12 +75,12 @@ public class QdrantEmbeddingStoreFactory implements EmbeddingStoreFactory {
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
-        return new LinkedHashSet<>(List.of(HOST, DIMENSION));
+        return new LinkedHashSet<>(List.of(HOST, PORT, DIMENSION));
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return new LinkedHashSet<>(List.of(PORT, API_KEY, COLLECTION_NAME_PREFIX, DISTANCE, USE_TLS));
+        return new LinkedHashSet<>(List.of(API_KEY, COLLECTION_NAME_PREFIX, DISTANCE, USE_TLS));
     }
 
     @Override

--- a/dat-storers/dat-storer-weaviate/src/main/java/ai/dat/storer/weaviate/WeaviateEmbeddingStoreFactory.java
+++ b/dat-storers/dat-storer-weaviate/src/main/java/ai/dat/storer/weaviate/WeaviateEmbeddingStoreFactory.java
@@ -63,12 +63,12 @@ public class WeaviateEmbeddingStoreFactory implements EmbeddingStoreFactory {
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
-        return Collections.emptySet();
+        return new LinkedHashSet<>(List.of(SCHEME, HOST, PORT));
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return new LinkedHashSet<>(List.of(SCHEME, HOST, PORT, API_KEY, CLASS_NAME_PREFIX));
+        return new LinkedHashSet<>(List.of(API_KEY, CLASS_NAME_PREFIX));
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * HOST and PORT are now required when configuring Milvus, PGVector, and Weaviate embedding stores
  * PORT configuration is now required for Qdrant embedding store
  * Weaviate additionally requires SCHEME configuration specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->