### PR TITLE
fix: linux arm64 workflow packaging OS is 'ubuntu-24.04-arm'

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
             maven_profile: os:linux-amd64,jar:built-in-small
             asset_suffix: linux-amd64
             package_type: unbundled
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             maven_profile: os:linux-arm64,jar:built-in-small
             asset_suffix: linux-arm64
             package_type: unbundled
@@ -51,7 +51,7 @@ jobs:
             maven_profile: os:linux-amd64,jar:built-in-small
             asset_suffix: linux-amd64
             package_type: bundled
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             maven_profile: os:linux-arm64,jar:built-in-small
             asset_suffix: linux-arm64
             package_type: bundled


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to target Ubuntu 24.04 ARM for package compilation variants, affecting both unbundled and bundled distribution types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->